### PR TITLE
fix(frontend): stabilize build + move Prisma to raw SQL (no model delegates)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "blog-frontend",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@mdx-js/react": "^3.1.1",

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -1,0 +1,17 @@
+export type PostSummary = {
+  id: number;
+  slug: string;
+  title: string;
+  lead: string | null;
+  section: string | null;
+  tags: string[] | null;
+  created_at: string;
+};
+
+export type PostFull = PostSummary & {
+  description: string | null;
+  body_mdx: string;
+  faq: Array<{ q: string; a: string }> | null;
+  citations: Array<{ url: string; title?: string; date?: string }> | null;
+  locale: string;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,13 +1,12 @@
 import type { Config } from 'tailwindcss';
+import typography from '@tailwindcss/typography';
 
 const config = {
   content: ['./app/**/*.{ts,tsx,mdx}', './src/**/*.{ts,tsx,mdx}'],
   theme: {
     extend: {}
   },
-  plugins: {
-    '@tailwindcss/typography': {}
-  }
+  plugins: [typography]
 } satisfies Config;
 
 export default config;


### PR DESCRIPTION
## Summary
- confirmed the existing tsconfig baseUrl/path alias and continued using the Prisma singleton at `src/lib/prisma`
- replaced the home and article pages with parameterized `prisma.$queryRaw` calls that share new content types and parse JSON payloads safely
- updated the Tailwind v4 plugin configuration, kept the PostCSS setup, and added a `prisma generate` postinstall while refreshing the lockfile

## Testing
- npm run lint
- npm install *(fails: Prisma engine download returns 403 even with `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING`)*

------
https://chatgpt.com/codex/tasks/task_e_68d7eab95b94832e817fd1f32a83bbca