### PR TITLE
fix: handle Next.js 15 async params in article metadata

### DIFF
--- a/app/artykuly/[slug]/page.tsx
+++ b/app/artykuly/[slug]/page.tsx
@@ -151,8 +151,13 @@ async function getPost(slug: string): Promise<PostResult | null> {
   } satisfies PostResult;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const result = await getPost(params.slug);
+type GenerateMetadataProps = {
+  params: Promise<PageProps['params']>;
+};
+
+export async function generateMetadata({ params }: GenerateMetadataProps): Promise<Metadata> {
+  const { slug } = await params;
+  const result = await getPost(slug);
 
   if (!result) {
     return {};
@@ -162,7 +167,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     title: result.post.title,
     description: result.post.description ?? result.post.lead ?? undefined,
     alternates: {
-      canonical: `/artykuly/${params.slug}`
+      canonical: `/artykuly/${slug}`
     }
   } satisfies Metadata;
 }


### PR DESCRIPTION
## Summary
- update the article page metadata generator to use the Next.js 15 async params API
- await the slug param before accessing it so the article route stops throwing the params usage error

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d81cf53adc832ea12fa902b8259a53