### PR TITLE
feat(frontend): rewrites + data-fetch fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL=postgresql://USER:PASS@HOST:5432/DB
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_BACKEND_URL=https://your-backend-host.example.com

--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ npm install
 
 ## Konfiguracja środowiska
 
-Skopiuj plik `.env.example` do `.env` i uzupełnij dane połączenia z bazą danych:
+Skopiuj plik `.env.example` do `.env` i uzupełnij wymagane wartości:
 
 ```bash
 cp .env.example .env
 ```
 
-Następnie zaktualizuj wartość `DATABASE_URL`.
+Następnie ustaw zmienne środowiskowe:
+
+- `DATABASE_URL` – połączenie z bazą danych (tylko dla lokalnego rozwoju).
+- `NEXT_PUBLIC_SITE_URL` – pełny adres aplikacji (np. `https://wiedza.joga.yoga`).
+- `NEXT_PUBLIC_BACKEND_URL` – host wdrożonego backendu (np. `https://backend.example.com`).
+
+> Na Vercelu skonfiguruj powyższe zmienne w zakładce **Project → Settings → Environment Variables**.
 
 ## Uruchomienie w trybie deweloperskim
 
@@ -37,6 +43,19 @@ Aplikacja będzie domyślnie dostępna pod adresem [http://localhost:3000](http:
 npm run build
 npm run start
 ```
+
+## Proxy do backendu
+
+Aplikacja korzysta z konfiguracji `rewrites` Next.js, aby serwować zapytania pod `/api/*` bezpośrednio z backendu. Dzięki temu unikamy problemów z CORS i możemy używać względnych ścieżek (`fetch('/api/posts')`).
+
+Proxy dodaje nagłówek `Cache-Control: no-store` dla odpowiedzi backendu oraz ustawia nagłówki bezpieczeństwa (`Referrer-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Permissions-Policy`).
+
+## Kontrakt API danych
+
+- Lista artykułów: `GET /api/posts` – zwraca tablicę obiektów z kluczami `slug`, `title`, `lead`, `section`, `tags`, `created_at` itd.
+- Pojedynczy artykuł: `GET /api/posts/{slug}` – zwraca obiekt artykułu z polami `body_mdx`, `faq`, `citations`.
+
+Komponenty frontendu normalizują odpowiedź, dlatego dodatkowe opakowania (`{ data: [...] }`, `{ post: {...} }`) są również obsługiwane.
 
 ## Generowanie klienta Prisma
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,58 @@
+const backendHost = process.env.NEXT_PUBLIC_BACKEND_URL ?? process.env.BACKEND_URL;
+
+if (!backendHost) {
+  throw new Error(
+    'NEXT_PUBLIC_BACKEND_URL environment variable is required to proxy API requests to the backend.'
+  );
+}
+
+const backendOrigin = backendHost.replace(/\/$/, '');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${backendOrigin}/:path*`
+      }
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: '/api/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-store'
+          }
+        ]
+      },
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin'
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff'
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY'
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'geolocation=(), microphone=(), camera=()'
+          }
+        ]
+      }
+    ];
+  }
 };
 
 export default nextConfig;

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -1,5 +1,5 @@
 export type PostSummary = {
-  id: number;
+  id: number | string;
   slug: string;
   title: string;
   lead: string | null;


### PR DESCRIPTION
## Summary
- add API rewrites with security headers and document required environment variables
- normalize list and detail article fetchers to use the proxied `/api/posts` endpoints with array guards
- ensure article metadata/canonicals resolve against the production domain

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ed2415e4832eba731abd3b651e2c