### PR TITLE
Fix Next 15 typing regressions

### DIFF
--- a/__tests__/articleDetailPage.test.tsx
+++ b/__tests__/articleDetailPage.test.tsx
@@ -54,7 +54,7 @@ it('renders article sections, FAQ and citations', async () => {
     updated_at: '2024-01-02T00:00:00Z'
   });
 
-  const ui = await ArticlePage({ params: { slug: 'transformacja-energetyczna' } });
+  const ui = await ArticlePage({ params: Promise.resolve({ slug: 'transformacja-energetyczna' }) });
   render(ui);
 
   expect(screen.getByRole('heading', { level: 1, name: /Transformacja energetyczna/i })).toBeInTheDocument();

--- a/__tests__/articlesPage.test.tsx
+++ b/__tests__/articlesPage.test.tsx
@@ -46,7 +46,7 @@ it('renders articles with pagination and tags', async () => {
     database_url_present: true
   });
 
-  const ui = await HomePage({ searchParams: {} });
+  const ui = await HomePage({ searchParams: Promise.resolve({}) });
   render(ui);
 
   expect(screen.getByText('Najnowsze artykuły')).toBeInTheDocument();
@@ -63,7 +63,7 @@ it('shows service downtime message when backend fails', async () => {
     database_url_present: false
   });
 
-  const ui = await HomePage({ searchParams: {} });
+  const ui = await HomePage({ searchParams: Promise.resolve({}) });
   render(ui);
 
   expect(screen.getByText('Serwis chwilowo niedostępny')).toBeInTheDocument();

--- a/app/artykuly/[slug]/page.tsx
+++ b/app/artykuly/[slug]/page.tsx
@@ -8,8 +8,10 @@ import type { ArticleCitation, ArticleDetailResponse, ArticleFaqItem } from '@/l
 
 export const revalidate = 600;
 
+type PageParams = { slug: string };
+
 type PageProps = {
-  params: { slug: string };
+  params: Promise<PageParams>;
 };
 
 type GenerateMetadataProps = {
@@ -80,8 +82,10 @@ function normalizeCitations(citations: ArticleCitation[]): ArticleCitation[] {
 }
 
 export async function generateMetadata({ params }: GenerateMetadataProps): Promise<Metadata> {
+  const { slug } = await params;
+
   try {
-    const article = await getArticle(params.slug, { revalidate });
+    const article = await getArticle(slug, { revalidate });
     const createdAt = article.created_at ?? article.updated_at;
     const updatedAt = article.updated_at ?? article.created_at;
     const robotsValue = article.seo.robots?.toLowerCase() ?? '';
@@ -124,10 +128,11 @@ export async function generateMetadata({ params }: GenerateMetadataProps): Promi
 }
 
 export default async function ArticlePage({ params }: PageProps) {
+  const { slug } = await params;
   let article: ArticleDetailResponse;
 
   try {
-    article = await getArticle(params.slug, { revalidate });
+    article = await getArticle(slug, { revalidate });
   } catch (error) {
     if (error instanceof NotFoundError) {
       notFound();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ const ARTICLES_PER_PAGE = 10;
 type SearchParams = Record<string, string | string[] | undefined>;
 
 type PageProps = {
-  searchParams?: Promise<SearchParams> | SearchParams;
+  searchParams?: Promise<SearchParams>;
 };
 
 type QueryState = {
@@ -72,7 +72,7 @@ function SectionFilter({
 }: {
   query: QueryState;
   articles: ArticleListResponse | null;
-}): JSX.Element {
+}) {
   const sections = new Set<string>();
 
   if (articles) {
@@ -126,7 +126,7 @@ function SectionFilter({
   );
 }
 
-function Pagination({ query, articles }: { query: QueryState; articles: ArticleListResponse }): JSX.Element | null {
+function Pagination({ query, articles }: { query: QueryState; articles: ArticleListResponse }) {
   const { meta } = articles;
 
   if (meta.total_pages <= 1) {
@@ -160,7 +160,7 @@ function Pagination({ query, articles }: { query: QueryState; articles: ArticleL
   );
 }
 
-function ArticleList({ articles, query }: { articles: ArticleListResponse; query: QueryState }): JSX.Element {
+function ArticleList({ articles, query }: { articles: ArticleListResponse; query: QueryState }) {
   if (articles.items.length === 0) {
     return (
       <div className="rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center text-gray-500">
@@ -203,7 +203,7 @@ function ArticleList({ articles, query }: { articles: ArticleListResponse; query
   );
 }
 
-function ArticlesFallback({ error }: { error: ApiError }): JSX.Element {
+function ArticlesFallback({ error }: { error: ApiError }) {
   const isUnavailable = error instanceof ServiceUnavailableError || error.status === 502 || error.status === 503;
 
   return (
@@ -223,7 +223,7 @@ function ArticlesFallback({ error }: { error: ApiError }): JSX.Element {
   );
 }
 
-function HealthNotice({ healthy }: { healthy: boolean }): JSX.Element | null {
+function HealthNotice({ healthy }: { healthy: boolean }) {
   if (healthy) {
     return null;
   }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,10 +1,11 @@
 import '@testing-library/jest-dom';
+import type { Ref } from 'react';
 
 jest.mock('react-markdown', () => {
   const React = require('react');
   return React.forwardRef(function MockReactMarkdown(
     { children }: { children: React.ReactNode; className?: string },
-    ref
+    ref: Ref<HTMLDivElement>
   ) {
     return React.createElement('div', { ref }, children);
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint",
     "test": "jest"

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -2,7 +2,6 @@
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { JSX } from 'react';
 
 type MarkdownProps = {
   children: string;
@@ -10,7 +9,7 @@ type MarkdownProps = {
   components?: Parameters<typeof ReactMarkdown>[0]['components'];
 };
 
-export function Markdown({ children, className, components }: MarkdownProps): JSX.Element {
+export function Markdown({ children, className, components }: MarkdownProps) {
   return (
     <ReactMarkdown
       className={['prose prose-neutral max-w-none', className].filter(Boolean).join(' ')}

--- a/src/components/articles/ArticleGeneratorForm.tsx
+++ b/src/components/articles/ArticleGeneratorForm.tsx
@@ -24,7 +24,7 @@ function parseKeywords(value: string): string[] {
     .slice(0, 6);
 }
 
-export function ArticleGeneratorForm({ rubrics }: ArticleGeneratorFormProps): JSX.Element {
+export function ArticleGeneratorForm({ rubrics }: ArticleGeneratorFormProps) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -43,7 +43,7 @@ export class NetworkError extends ApiError {
 export type ApiRequestOptions = Omit<RequestInit, 'body'> & {
   body?: RequestInit['body'];
   searchParams?: Record<string, string | number | boolean | null | undefined | Array<string | number | boolean>>;
-  revalidate?: number;
+  revalidate?: number | false;
 };
 
 export function getApiBaseUrl(): string {
@@ -101,13 +101,13 @@ export async function apiFetch<TResponse>(path: string, options: ApiRequestOptio
   const requestHeaders = new Headers(headers);
   requestHeaders.set('Accept', 'application/json');
 
-  const init: RequestInit & { next?: { revalidate?: number } } = {
+  const init: RequestInit & { next?: { revalidate?: number | false } } = {
     ...rest,
     headers: requestHeaders
   };
 
   if (revalidate !== undefined) {
-    init.next = { ...(rest as { next?: { revalidate?: number } }).next, revalidate };
+    init.next = { ...(rest as { next?: { revalidate?: number | false } }).next, revalidate };
   }
 
   if (body !== undefined) {

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -80,6 +80,11 @@ const taxonomySchema = z.object({
   tags: z.array(z.string()).default([])
 });
 
+export type ArticleCitation = {
+  url?: string;
+  label: string;
+};
+
 const citationValueSchema = z
   .union([
     z.string(),
@@ -140,15 +145,14 @@ export const articleDocumentSchema = z.object({
   })
 });
 
-export type ArticleDocument = z.infer<typeof articleDocumentSchema> & {
-  article: {
-    citations: ArticleCitation[];
-  } & ArticleDocument['article'];
+type ArticleDocumentSchema = z.infer<typeof articleDocumentSchema>;
+
+type ArticleBody = ArticleDocumentSchema['article'] & {
+  citations: ArticleCitation[];
 };
 
-export type ArticleCitation = {
-  url?: string;
-  label: string;
+export type ArticleDocument = Omit<ArticleDocumentSchema, 'article'> & {
+  article: ArticleBody;
 };
 
 export type ArticleFaqItem = z.infer<typeof faqItemSchema>;
@@ -158,8 +162,10 @@ export const articleDetailResponseSchema = articleDocumentSchema.extend({
   updated_at: z.string().optional()
 });
 
-export type ArticleDetailResponse = z.infer<typeof articleDetailResponseSchema> & {
-  article: ArticleDocument['article'];
+type ArticleDetailResponseSchema = z.infer<typeof articleDetailResponseSchema>;
+
+export type ArticleDetailResponse = Omit<ArticleDetailResponseSchema, 'article'> & {
+  article: ArticleBody;
 };
 
 export const articleCreateRequestSchema = z.object({
@@ -178,7 +184,11 @@ export const articlePublishResponseSchema = z.object({
   post: articleDetailResponseSchema.optional()
 });
 
-export type ArticlePublishResponse = z.infer<typeof articlePublishResponseSchema>;
+type ArticlePublishResponseSchema = z.infer<typeof articlePublishResponseSchema>;
+
+export type ArticlePublishResponse = Omit<ArticlePublishResponseSchema, 'post'> & {
+  post?: ArticleDetailResponse;
+};
 
 export const rubricSchema = z.object({
   code: z.string(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,27 +6,29 @@
       "dom.iterable",
       "esnext"
     ],
-    "allowJs": false,
-    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
     "strict": true,
     "noEmit": true,
-    "incremental": true,
-    "module": "esnext",
+    "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     },
     "esModuleInterop": true,
-    "verbatimModuleSyntax": true,
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"
       }
-    ]
+    ],
+    "allowJs": true,
+    "incremental": true,
+    "module": "esnext"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- align the TypeScript configuration with Next.js 15 expectations and React 19 type-only imports
- update page components and tests to rely on async route params/searchParams instead of explicit JSX return annotations
- relax fetch client typing and restructure API response types to avoid recursive definitions while keeping article data required
- switch the build script to `next build` for parity with local verification

## Testing
- `npx tsc --noEmit --pretty false`
- `CI=1 npx next build`


------
https://chatgpt.com/codex/tasks/task_e_68e4f405f7a8832e8c4b3247cf69c1b8