### PR TITLE
Add middleware to set robots header for q queries

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  if (!request.nextUrl.searchParams.has('q')) {
+    return NextResponse.next();
+  }
+
+  const response = NextResponse.next();
+  response.headers.set('X-Robots-Tag', 'noindex, follow');
+  return response;
+}


### PR DESCRIPTION
## Summary
- add middleware to set X-Robots-Tag header when q query parameter is present

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694facc54334832e830ea899f2d97dfc)